### PR TITLE
Add missing primesieve in extra-libraries for library

### DIFF
--- a/primesieve/primesieve.cabal
+++ b/primesieve/primesieve.cabal
@@ -24,6 +24,7 @@ library
                      , OverloadedStrings
   build-depends:       base >= 4.7 && < 5
                      , foundation
+  extra-libraries:     primesieve
 
 executable prime-count
   hs-source-dirs:      example


### PR DESCRIPTION
Without this, I cannot use the library:

```
$ ghci
GHCi, version 8.6.3: http://www.haskell.org/ghc/  :? for help
Loaded GHCi configuration from /home/guillaume/srcs/computations/primesieve/.ghci
Prelude> import Math.Prime.FastSieve 
Prelude Math.Prime.FastSieve> countPrimes 2 (2 * 10 ^ 9)
can't load .so/.DLL for: /nix/store/9jmkf4a0pm5czy0xpjj07aw6bhqwiy6m-primesieve-0.1.0.1/lib/ghc-8.6.3/x86_64-linux-ghc-8.6.3/libHSprimesieve-0.1.0.1-CPb1OiuF6wL9lRQ682Wche-ghc8.6.3.so (/nix/store/9jmkf4a0pm5czy0xpjj07aw6bhqwiy6m-primesieve-0.1.0.1/lib/ghc-8.6.3/x86_64-linux-ghc-8.6.3/libHSprimesieve-0.1.0.1-CPb1OiuF6wL9lRQ682Wche-ghc8.6.3.so: undefined symbol: primesieve_free)
```