### PR TITLE
Bring primesieve up-to-date

### DIFF
--- a/primesieve/primesieve.cabal
+++ b/primesieve/primesieve.cabal
@@ -23,6 +23,7 @@ library
   default-extensions:  NoImplicitPrelude
                      , OverloadedStrings
   build-depends:       base >= 4.7 && < 5
+                     , basement
                      , foundation
   extra-libraries:     primesieve, stdc++
 

--- a/primesieve/primesieve.cabal
+++ b/primesieve/primesieve.cabal
@@ -24,7 +24,7 @@ library
                      , OverloadedStrings
   build-depends:       base >= 4.7 && < 5
                      , foundation
-  extra-libraries:     primesieve, libstdc++
+  extra-libraries:     primesieve, stdc++
 
 executable prime-count
   hs-source-dirs:      example

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,12 +2,12 @@ flags: {}
 extra-package-dbs: []
 packages:
 # - algo
-# - primesieve
-- intuition-plugin
-- stat-ml
-- math-foreign
-- xgboost-haskell
-- opt-solver
+- primesieve
+# - intuition-plugin
+# - stat-ml
+# - math-foreign
+# - xgboost-haskell
+# - opt-solver
 extra-deps:
 - z3-4.1.1
-resolver: nightly-2017-10-11
+resolver: lts-22.13


### PR DESCRIPTION
Two changes to bring the primesieve project up-to-date:
* Fix the build of primesieve by updating `stack.yaml` and `primesieve.cabal`.
* Implement a `Storable CSize` instance, which is required by the implementation of `generatePrimes`.