### PR TITLE
Remove dependency on basement and foundation

### DIFF
--- a/primesieve/example/Count.hs
+++ b/primesieve/example/Count.hs
@@ -1,5 +1,3 @@
-import Foundation
-
 import Math.Prime.FastSieve
 
 -- Test the results of prime count.

--- a/primesieve/example/Main.hs
+++ b/primesieve/example/Main.hs
@@ -1,6 +1,7 @@
 module Main where
 
-import Foundation
+import Data.Int (Int32)
+import Data.Vector.Storable (Vector, sum)
 
 import Math.Prime.FastSieve
 
@@ -8,7 +9,8 @@ main :: IO ()
 main = do
     primesieveVersion >>= putStrLn . ("Version of primesieve: " <>)
     
-    ns <- generateNPrimes 10 0 :: IO (UArray Int32)
+    ns <- generateNPrimes 10 0 :: IO (Vector Int32)
+
     putStrLn $ "The first 10 primes: " <> show ns
 
     putStrLn $ "Count of primes between 100 and 1000000: " <> show (countPrimes 100 1000000)

--- a/primesieve/primesieve.cabal
+++ b/primesieve/primesieve.cabal
@@ -20,29 +20,24 @@ library
   other-modules:
     Math.Prime.FastSieve.FFI
   default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
-                     , OverloadedStrings
+  default-extensions:  OverloadedStrings
   build-depends:       base >= 4.7 && < 5
-                     , basement
-                     , foundation
-  extra-libraries:     primesieve, stdc++
+                     , vector
+  extra-libraries:     primesieve
 
 executable prime-count
   hs-source-dirs:      example
   main-is:             Count.hs
   default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
-                     , OverloadedStrings
+  default-extensions:  OverloadedStrings
   build-depends:       base >= 4.7 && < 5
-                     , foundation
                      , primesieve
 
 executable prime-example
   hs-source-dirs:      example
   main-is:             Main.hs
   default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
-                     , OverloadedStrings
+  default-extensions:  OverloadedStrings
   build-depends:       base >= 4.7 && < 5
-                     , foundation
                      , primesieve
+                     , vector


### PR DESCRIPTION
`basement` and `foundation` are now [deprecated](https://github.com/haskell-foundation/foundation). We remove the dependency on these libraries and amend `generatePrimes`/`generateNPrimes` to return `Vector`s instead of `UArray`s.