### PR TITLE
Add functions from primesieve/iterator.h

### DIFF
--- a/primesieve/cbits/primesieve_iterator_size.c
+++ b/primesieve/cbits/primesieve_iterator_size.c
@@ -1,0 +1,5 @@
+#include <primesieve/iterator.h>
+
+size_t primesieve_iterator_size() {
+  return sizeof(primesieve_iterator);
+}

--- a/primesieve/primesieve.cabal
+++ b/primesieve/primesieve.cabal
@@ -15,6 +15,8 @@ extra-source-files:  README.md
 
 library
   hs-source-dirs:      src
+  c-sources:
+    cbits/primesieve_iterator_size.c
   exposed-modules:
     Math.Prime.FastSieve
   other-modules:

--- a/primesieve/src/Math/Prime/FastSieve.hs
+++ b/primesieve/src/Math/Prime/FastSieve.hs
@@ -18,6 +18,10 @@ module Math.Prime.FastSieve
     , setSieveSize
     , setNumThreads
     , primesieveVersion
+    , primes
+    , primesFrom
+    , primesTo
+    , primesFromTo
     ) where
 
 import Math.Prime.FastSieve.FFI


### PR DESCRIPTION
The primesieve C API has another header `primesieve/iterator.h` that has functions for generating prime numbers through an iterator interface. We import these functions into the Haskell library, and use them to create functions `primes`, `primesTo`, `primesFrom`, `primesFromTo` that lazily generate lists of primes.